### PR TITLE
No serialization necessary

### DIFF
--- a/docs/connect-options.md
+++ b/docs/connect-options.md
@@ -1,7 +1,49 @@
 @typedef {{}} react-view-models.connect.options connect options
 @parent react-view-models.connect.types
 
-@description The `options` object is an optional argument passed as the third parameter to connect, that customizes the [container component](https://medium.com/@dan_abramov/smart-and-dumb-components-7ca2f9a7c7d0#.v9i90qbq8) returned.
+@description The `options` object, passed as the third parameter to connect, configures which properties of the view-model will be passed into the child component and customizes the [container component](https://medium.com/@dan_abramov/smart-and-dumb-components-7ca2f9a7c7d0#.v9i90qbq8) returned.
+
+@option {Object} properties
+
+The keys of the `properties` object represent the properties of the view-model that will get passed down to the child component, usually a presentational component. The values of the `properties` can be:
+ - `true` - meaning yes pass this value down
+ - `false` - stop any properties from being passed down
+ - `nobind` - stop any view-model methods being passed down from automatically binding it's **context** to the view-model
+ - `asArray` - to turn array like properties, like DefineLists, into actual arrays before passing into the React component where arrays are more expected and useful than DefineLists
+
+The `nobind` and `asArray` **special values** can be imported as a named import from `react-view-models`.
+
+```js
+import connect, { asArray, nobind } from 'react-view-models';
+
+const options = {
+  properties: {
+    'list': asArray,
+    'name': true,
+    'onClick': nobind,
+    'onUserSelect': true
+  }
+};
+
+export default connect( ViewModel, App, options );
+```
+
+There is also a **special spread key** (`...`), which can be put on `properties` and if the value is `true`, any `props` passed into the **Connected Container Component** will also be "spread" onto the child component.
+
+Any view-model `properties` set to true will of course override spread `props` values, and if the property key is set to `false`, it will not be spread onto the child component.
+
+```js
+const options = {
+  properties: {
+    '...': true,
+    'notPassedThrough': false,
+    'onViewModel': true
+  },
+  displayName: 'UserListComponent'
+}
+
+connect( UserListViewModel, ListComponent, options )
+```
 
 @option {string} displayName
 
@@ -10,4 +52,28 @@ The `displayName` property will be the [container components](https://medium.com
 
 ```js
 connect( UserListViewModel, ListComponent, { displayName: 'UserListComponent' } )
+```
+
+@option {boolean} deepObserve
+
+The `deepObserve` options, is to allow you to observe changes to observables nested within the objects you are passing as props, in case components further down the tree use properties on the nested components and therefore need to be notified if they change.
+
+**There is probably no good reason to use this option and it is very costly performance-wise.**
+
+You would be better off, upgrading the component that is using properties on these nested observables, to a container component with a view-model, then you can use the nested component in your view model, and it will be observable for that component, without having to use the deepObserve option.
+
+This option is here only as a last resort, or to aid in debugging.
+
+```js
+const options = {
+  properties: {
+    'users': true,
+    'tickets': true
+    'onTicketSubmit': true
+  },
+  displayName: 'UserTicketExchange',
+  deepObserve: true
+}
+
+connect( UserListViewModel, ListComponent, options )
 ```

--- a/docs/connect-options.md
+++ b/docs/connect-options.md
@@ -8,7 +8,7 @@
 The keys of the `properties` object represent the properties of the view-model that will get passed down to the child component, usually a presentational component. The values of the `properties` can be:
  - `true` - meaning yes pass this value down
  - `false` - stop any properties from being passed down
- - `nobind` - stop any view-model methods being passed down from automatically binding it's **context** to the view-model
+ - `nobind` - stop any view-model methods being passed down from automatically binding its **context** to the view-model
  - `asArray` - to turn array like properties, like DefineLists, into actual arrays before passing into the React component where arrays are more expected and useful than DefineLists
 
 The `nobind` and `asArray` **special values** can be imported as a named import from `react-view-models`.

--- a/docs/connect.md
+++ b/docs/connect.md
@@ -4,7 +4,7 @@
 
 @description connects a [DefineMap](./can-define/map/map.html) class to a React component to create a new auto-rendering component with an observable view-model
 
-@signature `connect( ViewModel, ReactComponent[, options] )`
+@signature `connect( ViewModel, ReactComponent, options )`
 
 Creates an auto rendering [container component](https://medium.com/@dan_abramov/smart-and-dumb-components-7ca2f9a7c7d0#.v9i90qbq8) by connecting an observable view-model to a React [presentational components](https://medium.com/@dan_abramov/smart-and-dumb-components-7ca2f9a7c7d0#.v9i90qbq8)
 
@@ -14,11 +14,11 @@ export default connect( UserListViewModel, ListView, { displayName: 'UserList' }
 
 @param {can-define/map/map} ViewModel A [DefineMap](./can-define/map/map.html) class / constructor function
 @param {ReactComponent} ReactComponent Any React component
-@param {react-view-models.connect.options} options optional options object
+@param {react-view-models.connect.options} options options object
 
 @return {ReactComponent} A React [container component](https://medium.com/@dan_abramov/smart-and-dumb-components-7ca2f9a7c7d0#.v9i90qbq8)
 
-@signature `connect( mapToProps, ReactComponent[, options] )`
+@signature `connect( mapToProps, ReactComponent, options )`
 
 Creates an auto rendering [container component](https://medium.com/@dan_abramov/smart-and-dumb-components-7ca2f9a7c7d0#.v9i90qbq8) by connecting a mapToProps function to a React [presentational components](https://medium.com/@dan_abramov/smart-and-dumb-components-7ca2f9a7c7d0#.v9i90qbq8) as a pseudo-view model. The `mapToProps` function receives one argument, the props of the container component, and will return an object to pass as `props` to the presentational component.
 
@@ -33,6 +33,6 @@ export default connect( props => ({ listItems: users }), ListView, { displayName
 
 @param {Function} mapToProps A function that has a props argument and returns props
 @param {ReactComponent} ReactComponent Any React component
-@param {react-view-models.connect.options} options optional options object
+@param {react-view-models.connect.options} options options object
 
 @return {ReactComponent} A React [container component](https://medium.com/@dan_abramov/smart-and-dumb-components-7ca2f9a7c7d0#.v9i90qbq8)

--- a/docs/react-view-models.md
+++ b/docs/react-view-models.md
@@ -14,7 +14,7 @@
 
 React-View-Models follows the pattern popularized by [react-redux](https://github.com/reactjs/react-redux), and provide users with a [react-view-models.connect connect] function for extending [React](https://facebook.github.io/react/) Presentational Components into Container Components, by providing `connect` with either a `mapToProps` function or more commonly a `ViewModel` constructor function, which is an extended [DefineMap](./can-define/map/map.html) class, along with a presentational component, just like react-redux does.
 
-The `ViewModel` is an observable, and when any observable change happens to one of it's properties, or if new props get set on the Container Component, some of the view-models properties will be sent into the connected component as props, forcing an update/render.
+The `ViewModel` is an observable, and when any observable change happens to one of it's properties, or if new props get set on the Container Component, some of the view-model's properties will be sent into the connected component as props, forcing an update/render.
 
 The `mapToProps` function will get converted to a compute, so when any observable read inside the compute emits a change (or if new props get set on the Container Component), it will update the wrapped/connected presentational component instance with new derived props.
 

--- a/docs/react-view-models.md
+++ b/docs/react-view-models.md
@@ -8,17 +8,17 @@
 
 `react-view-models` is a library to connect observable view-models to [React](https://facebook.github.io/react/) [presentational components](https://medium.com/@dan_abramov/smart-and-dumb-components-7ca2f9a7c7d0#.v9i90qbq8) to create auto rendering [container components](https://medium.com/@dan_abramov/smart-and-dumb-components-7ca2f9a7c7d0#.v9i90qbq8).
 
-- The [react-view-models.connect connect] method takes a [DefineMap](./can-define/map/map.html) class and a React component class, and returns a new React Component which will autorender when obsevable changes happen on the view model
+- The [react-view-models.connect connect] method takes a [DefineMap](./can-define/map/map.html) class and a React component class, and returns a new React Component which will auto-render when observable changes happen on the view-model
 
 @body
 
 React-View-Models follows the pattern popularized by [react-redux](https://github.com/reactjs/react-redux), and provide users with a [react-view-models.connect connect] function for extending [React](https://facebook.github.io/react/) Presentational Components into Container Components, by providing `connect` with either a `mapToProps` function or more commonly a `ViewModel` constructor function, which is an extended [DefineMap](./can-define/map/map.html) class, along with a presentational component, just like react-redux does.
 
-The `ViewModel` is an observable, and when any observable change happens to one of it's properties, or if new props get set on the Container Component, it will be serialized and sent into the connected component as props, forcing an update/render.
+The `ViewModel` is an observable, and when any observable change happens to one of it's properties, or if new props get set on the Container Component, some of the view-models properties will be sent into the connected component as props, forcing an update/render.
 
 The `mapToProps` function will get converted to a compute, so when any observable read inside the compute emits a change (or if new props get set on the Container Component), it will update the wrapped/connected presentational component instance with new derived props.
 
-By following the patterns established by react-redux, but avoiding the complexity of pure-functional programing, reducer composition, immutability, and the single store paradigm, we hope to offer a familiar, powerful, but far simpler solution to creating great backing data stores for your react app.
+By following the patterns established by react-redux, but avoiding the complexity of pure-functional programing, reducer composition, immutability, and the single store paradigm, we hope to offer a familiar, powerful, but far simpler solution to creating great state management and data stores for your react app.
 
 ## Use
 
@@ -32,25 +32,37 @@ var Item = require('../models/items');
 
 var items = Items.getList({ selected: true });
 
+var options = {
+  properties: {
+    text: true,
+    onClick: true
+  },
+  displayName: 'SaveItemsButton'
+}
+
 var ViewModel = DefineMap.extend({
   text: {
-    get() {
+    get: function() {
       return `Save ${items.length} items`;
     }
   },
-  onClick() {
+  onClick: function() {
     items.saveAllItems();
   }
 });
 
-module.exports = connect( ViewModel, Button );
+module.exports = connect( ViewModel, Button, options );
 ```
 
-Every instance of the returned **container component** will generate an instance of the `viewModel` and provide `props` to the connected component based on the serialized `viewModel` instance.
+Every instance of the returned **container component** will generate an instance of `ViewModel` and provide `props` to the connected component based on the `options.properties` object and the `viewModel`.
 
-The **ViewModel** instance will be initialized with the `props` passed into the Container Component. Whenever the container component will receive new `props`, the `props` object is passed to the viewModels `.set()` method, which may in turn cause an observable change event, which will re-run the serialization process and provide the connected component new props, which in turn may cause a new render.
+The **ViewModel** instance will be initialized with the `props` passed into the Container Component. Whenever the container component will receive new `props`, the `props` object is passed to the viewModels `.set()` method, which may in turn cause an observable change event, which will re-run the observed render process and provide the child component new props, which may cause a new render.
 
-Methods on the view model, and copied onto the serialized props object and bound to the viewModel, so that they may be used as callbacks for the connected component, while still being called with the correct context.
+Methods on the view model and specified in the `options.properties` object, will be copied onto the props object and bound to the viewModel, so that they may be used as callbacks for the connected component, while still being called with the correct context.
+
+_note: There is an option to **not** bind the callback to the view-model, by using the special `options.properties` value `nobind`, in case you need an unbound callback._
+
+Since the **Container Component** doesn't produce DOM artifacts of it’s own, you won’t end up with any wrapper divs or anything to worry about, but in react-device-tools you will see the component with the name you pass in `options.displayName` (or defaults to `Connected( MyComponent )`) in the tree. When using a view-model the **Container Component** holds the view-model value as its `state` but will also be available on the component instance as a property `.viewModel`.
 
 #### Example:
 
@@ -59,6 +71,15 @@ var connect = require('react-view-models').connect;
 var DefineMap = require('can-define/map/');
 var TodoComponent = require('components/todo.jsx');
 var Todo = require('models/todo');
+
+var options = {
+  properties: {
+    showOnlyCompleted: true,
+    todos: true,
+    addTodo: true
+  },
+  displayName: 'TodoList'
+}
 
 var ViewModel = DefineMap.extend({
   showOnlyCompleted: 'boolean',
@@ -71,16 +92,16 @@ var ViewModel = DefineMap.extend({
   }
 });
 
-module.exports = connect( ViewModel, TodoComponent );
+module.exports = connect( ViewModel, TodoComponent, options );
 ```
 
 The **mapToProps** function has one parameter, `ownProps`, which are the props that would have normally been passed into this component instance, as defined by the owner template (JSX).
 
-The return value of the **mapToProps** function will be an object, mapping the values to be used as props to the Presentational Components instance, and will be merged into the props the component would already be receiving from it's owner in the template it is used in (MapToProps values will overwrite the props passed in through the template). Since React components should not really be expecting observables, it may be appropriate (though not required) to serialize any observables in the mapToProps function (using `attr`, `serialize`, `.map` and `.reduce` ) when computing the value. Expecting observables in your react code will reduce re-usability).
-
-Since the Container Component doesn't produce DOM artifacts of it's own, you won't end up with any wrapper divs or anything to worry about, but in react-device-tools you will see the component with the name `connected( MyComponent )` in the tree. The Container Component holds the "newly computed props" value as its `state`. That state will update whenever the component "receives new props" or the compute emits a "change" event, which will then pass props down into the connected component instance, possibly causing some parts to re-render.
+The return value of the **mapToProps** function will be an object, mapping the values to be used as props to the **Presentational Components** instance. Expecting observables in your react code will reduce re-usability, so any components should treat them as regular objects and lists.
 
 Any user actions that should affect the state should be handled with callbacks on props (like `onClick` or `onSelectNewCountry`), and should be implemented in the MapToProps function as methods on the return value. The callback methods can be used to directly act on the observables.
+
+You do **not** need to supply the `options.properties` object when using a `mapToProps` function, and in fact it will be ignored if you do.
 
 #### Example:
 
@@ -100,10 +121,9 @@ module.exports = connect( ownProps => {
 ```
 
 ## Common use cases when using a view model
-
 Here are some examples that may come up when using a view-model that may not be obvious at first:
 
-### Transforming a prop before passing it down to a child component
+#### Transforming a prop before passing it down to a child component
 
 Sometimes you want a prop that is set on your connected component to be set to the exact same prop key on the child component, but modified slightly before passing it down. Here's an example of that:
 
@@ -117,24 +137,30 @@ const ViewModel = DefineMap.extend({
 });
 ```
 
-### Not passing through all props to the child component by default
+#### passing through props to the child component
+By default, any props passed into the connected component will be set on your view-model. You control which props get passed down into the child component using the `options.properties` object, and they will pass nothing by default.
 
-By default, any props passed into the connected component will be passed down into the child component, unless otherwise tampered with. You control which props get passed down by setting a serialize param on each property, a using the `'*'` key to set the default to false.
+You can also use a *special spread key* in the `options.properties` object, which will spread any properties passed to the connected component, onto the child component by default. Of course any view-model properties specified in `options.properties` will override the spread props.
 
 ```javascript
+const options = {
+  properties: {
+    '...': true,
+    'notToBePassedDown': false,
+    'upperCasedBeforePassingThrough': true
+  }
+}
+
 const ViewModel = DefineMap.extend({
-  '*': {
-    serialize: false
-  },
-  somePropToBePassedThrough: {
-    type: 'any',
-    serialize: true
+  set upperCasedBeforePassingThrough(value) {
+    return value.toUpperCase();
   }
 });
+
+export default connect( ViewModel, MyComponent, options )
 ```
 
-### Calling a parents callback, while also doing something special in your view models callback
-
+#### Calling a parents callback, while also doing something special in your view models callback
 Sometimes, you still want to notify the connected components owner component that the state changed (by calling a callback), but only after or while doing something different within the view-model. In this case, you'll want to define the callback prop as a observable attribute with a getter, rather than a method, and use the `lastSetVal` argument to call the parent components callback.
 
 ```javascript
@@ -148,10 +174,8 @@ const ViewModel = DefineMap.extend({
           return lastSetValue(ev);
         }
       };
-    },
-    serialize: true
+    }
   }
 });
 ```
-
 > _This can be one of the tricker conceits of the current API, suggestions are welcome._

--- a/package.json
+++ b/package.json
@@ -60,26 +60,26 @@
     ]
   },
   "dependencies": {
-    "can-compute": "^3.0.3",
-    "can-define": "^1.0.4",
-    "react": "^15.4.2",
-    "react-addons-test-utils": "^15.4.2",
-    "react-dom": "^15.4.2"
+    "can-compute": "^3.0.5",
+    "can-define": "^1.0.15",
+    "react": "^15.4.2"
   },
   "devDependencies": {
     "cssify": "^1.0.2",
     "documentjs": "^0.4.4",
     "donejs-cli": "^0.9.5",
-    "eslint": "^3.1.1",
+    "eslint": "^3.14.1",
     "eslint-plugin-react": "^6.5.0",
     "generator-donejs": "^0.9.4",
     "lite-server": "^2.2.2",
-    "steal": "^1.0.11",
+    "react-addons-test-utils": "^15.4.2",
+    "react-dom": "^15.4.2",
+    "steal": "^1.1.0",
     "steal-builtins": "^1.0.0",
     "steal-css": "^1.2.0",
     "steal-jsx": "0.0.2",
     "steal-qunit": "^1.0.0",
-    "steal-tools": "^1.0.3",
-    "testee": "^0.3.0-pre.2"
+    "steal-tools": "^1.1.1",
+    "testee": "^0.3.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "develop": "lite-server"
   },
   "main": "dist/cjs/react-view-models",
-  "browser": "dist/global/react-view-models",
   "browserify": {
     "transform": [
       "cssify"

--- a/package.json
+++ b/package.json
@@ -61,10 +61,12 @@
   },
   "dependencies": {
     "can-compute": "^3.0.5",
-    "can-define": "^1.0.15",
+    "can-types": "^1.0.2",
+    "can-util": "^3.2.2",
     "react": "^15.4.2"
   },
   "devDependencies": {
+    "can-define": "^1.0.15",
     "cssify": "^1.0.2",
     "documentjs": "^0.4.4",
     "donejs-cli": "^0.9.5",

--- a/react-view-models.js
+++ b/react-view-models.js
@@ -50,7 +50,7 @@ export function connect( ViewModel, ComponentToConnect, {
       if (deepObserve) {
         vm.get();
       }
-      const props = extractProps( vm, properties );
+      let props = extractProps( vm, properties, this.props );
       return React.createElement( ComponentToConnect, props, this.props.children );
     }
 
@@ -78,9 +78,18 @@ export function connect( ViewModel, ComponentToConnect, {
 export default connect;
 
 // exported for testing only
-export function extractProps( vm, properties ) {
+// NOTE: this is the most complicated part, maybe refactor so it's easier to read?
+export function extractProps( vm, properties, ownProps ) {
   const props = {};
+  if ( properties['...'] ) {
+    Object.keys(ownProps).forEach(key => {
+      if ( properties[key] !== false ) {
+        props[key] = ownProps[key];
+      }
+    });
+  }
   Object.keys(properties).forEach(key => {
+    if (key === '...') return; // ignore special spread key
     const propertyVal = properties[key];
     if ( propertyVal ) {
       const bindFunction = typeof vm[key] === 'function' && propertyVal !== nobind;

--- a/readme.md
+++ b/readme.md
@@ -31,6 +31,14 @@ import Item from '../models/items';
 
 let items = Items.getList({ selected: true });
 
+const options = {
+  properties: {
+    text: true,
+    onClick: true
+  },
+  displayName: 'SaveItemsButton'
+}
+
 export const ViewModel = DefineMap.extend({
   text: {
     get() {
@@ -42,23 +50,27 @@ export const ViewModel = DefineMap.extend({
   }
 });
 
-export default connect( ViewModel, Button );
+export default connect( ViewModel, Button, options );
 ```
 
 ## API
-#### `connect( {ViewModel|mapToProps}, Component ) `
+#### `connect( {ViewModel|mapToProps}, Component, options ) `
 Connect a view-model class or mapToProps function to React [presentational components][1]
 
-`connect()` takes 2 arguments. The first is either a **mapToProps** function, a function that will return an object that the component instance will receive as `props`, or a **ViewModel** constructor function, which is an extended [can-define/map][2]. The second argument is a **Presentational Component** constructor function (a.k.a. a class or just component in React). The `connect()` function returns a **Container Component** which can then be imported and used in any react component or render function as usual.
+`connect()` takes 3 arguments. The first is either a **mapToProps** function, a function that will return an object that the component instance will receive as `props`, or a **ViewModel** constructor function, which is an extended [can-define/map][2]. The second argument is a **Presentational Component** constructor function (a.k.a. a class or just component in React). The `connect()` function returns a **Container Component** which can then be imported and used in any react component or render function as usual.
 
 ##### ViewModel `{constructor function}`
 A [DefineMap][2] constructor function.
 
-Every instance of the returned component will generate an instance of the viewModel and provide props to the connected component based on the serialized Map instance.
+Every instance of the returned component will generate an instance of the viewModel and provide props to the connected component based on the `options.properties` object and the viewModel.
 
-The `ViewModel` instance will be initialized with the `props` passed into the Container Component. Whenever the container component will receive new `props`, the `props` object is passed to the viewModels `.set()` method, which may in turn cause an observable change event, which will re-run the serialization process and provide the connected component new props, which may cause a new render.
+The `ViewModel` instance will be initialized with the `props` passed into the Container Component. Whenever the container component will receive new `props`, the `props` object is passed to the viewModels `.set()` method, which may in turn cause an observable change event, which will re-run the observed render process and provide the child component new props, which may cause a new render.
 
-Methods on the view model, and copied onto the serialized props object and bound to the viewModel, so that they may be used as callbacks for the connected component, while still being called with the correct context.
+Methods on the view model and specified in the `options.properties` object, will be copied onto the props object and bound to the viewModel, so that they may be used as callbacks for the connected component, while still being called with the correct context.
+
+_note: There is an option to **not** bind the callback to the view-model, by using the special `options.properties` value `nobind`, in case you need an unbound callback._
+
+Since the **Container Component** doesn't produce DOM artifacts of it’s own, you won’t end up with any wrapper divs or anything to worry about, but in react-device-tools you will see the component with the name you pass in `options.displayName` (or defaults to `Connected( MyComponent )`) in the tree. When using a view-model the **Container Component** holds the view-model value as its `state` but will also be available on the component instance as a property `.viewModel`.
 
 #### Example:
 ```javascript
@@ -67,18 +79,26 @@ import DefineMap from 'can-define/map/map';
 import TodoComponent from 'components/todo.jsx';
 import Todo from 'models/todo';
 
+const options = {
+  properties: {
+    showOnlyCompleted: true,
+    todos: true,
+    addTodo: true
+  },
+  displayName: 'TodoList'
+}
+
 const ViewModel = DefineMap.extend({
   showOnlyCompleted: 'boolean',
   todos: {
     value: Todo.getList( { completed: this.showOnlyCompleted } ),
-    serialize: true
   },
   addTodo(formValues) {
     new Todo(formValues).save()
   }
 });
 
-export default connect( ViewModel, TodoComponent );
+export default connect( ViewModel, TodoComponent, options );
 ```
 
 ##### mapToProps `{function}`
@@ -86,11 +106,11 @@ A function that receives props as an argument and returns `props` to be sent to 
 
 The **mapToProps** function has one parameter, `ownProps`, which are the props that would have normally been passed into this component instance, as defined by the owner template (JSX).
 
-The return value of the **mapToProps** function will be an object, mapping the values to be used as props to the Presentational Components instance, and will be merged into the props the component would already be receiving from it’s owner in the template it is used in (MapToProps values will overwrite the props passed in through the template). Since React components should not really be expecting observables, it may be appropriate (though not required) to serialize any observables in the mapToProps function (using `attr`, `serialize`, `.map` and `.reduce` ) when computing the value. Expecting observables in your react code will reduce re-usability).
-
-Since the Container Component doesn't produce DOM artifacts of it’s own, you won’t end up with any wrapper divs or anything to worry about, but in react-device-tools you will see the component with the name `connected( MyComponent )` in the tree. The Container Component holds the “newly computed props” value as its `state`. That state will update whenever the component “receives new props” or the compute emits a “change” event, which will then pass props down into the connected component instance, possibly causing some parts to re-render.
+The return value of the **mapToProps** function will be an object, mapping the values to be used as props to the **Presentational Components** instance. Expecting observables in your react code will reduce re-usability, so any components should treat them as regular objects and lists.
 
 Any user actions that should affect the state should be handled with callbacks on props (like `onClick` or `onSelectNewCountry`), and should be implemented in the MapToProps function as methods on the return value. The callback methods can be used to directly act on the observables.
+
+You do **not** need to supply the `options.properties` object when using a `mapToProps` function, and in fact it will be ignored if you do.
 
 #### Example:
 ```javascript
@@ -126,20 +146,27 @@ const ViewModel = DefineMap.extend({
 });
 ```
 
-#### Not passing through all props to the child component by default
-By default, any props passed into the connected component will be passed down into the child component, unless otherwise tampered with. You control which props get passed down by setting a serialize param on each property, a using the `'*'` key to set the default to false.
+#### passing through props to the child component
+By default, any props passed into the connected component will be set on your view-model. You control which props get passed down into the child component using the `options.properties` object, and they will pass nothing by default.
 
+You can also use a *special spread key* in the `options.properties` object, which will spread any properties passed to the connected component, onto the child component by default. Of course any view-model properties specified in `options.properties` will override the spread props.
 
 ```javascript
+const options = {
+  properties: {
+    '...': true,
+    'notToBePassedDown': false,
+    'upperCasedBeforePassingThrough': true
+  }
+}
+
 const ViewModel = DefineMap.extend({
-  '*': {
-    serialize: false
-  },
-  somePropToBePassedThrough: {
-    type: 'any',
-    serialize: true
+  set upperCasedBeforePassingThrough(value) {
+    return value.toUpperCase();
   }
 });
+
+export default connect( ViewModel, MyComponent, options )
 ```
 
 #### Calling a parents callback, while also doing something special in your view models callback
@@ -156,8 +183,7 @@ const ViewModel = DefineMap.extend({
           return lastSetValue(ev);
         }
       };
-    },
-    serialize: true
+    }
   }
 });
 ```
@@ -180,11 +206,11 @@ npm test
 
 React-View-Models follows the pattern popularized by [react-redux][4], and provide users with a `connect()` function for extending React Presentational Components into Container Components, by providing `connect` with either a `mapToProps` function or more commonly a `ViewModel`  constructor function, which is an extended [DefineMap][2] class, along with a presentational component, just like react-redux does.
 
-The `ViewModel` is an observable, and when any observable change happens to one of it's properties, or if new props get set on the Container Component, it will be serialized and sent into the connected component as props, forcing an update/render.
+The `ViewModel` is an observable, and when any observable change happens to one of it's properties, or if new props get set on the Container Component, some of the view-models properties will be sent into the connected component as props, forcing an update/render.
 
 The `mapToProps` function will get converted to a compute, so when any observable read inside the compute emits a change (or if new props get set on the Container Component), it will update the wrapped/connected presentational component instance with new derived props.
 
-By following the patterns established by react-redux, but avoiding the complexity of pure-functional programing, reducer composition, immutability, and the single store paradigm, we hope to offer a familiar, powerful, but far simpler solution to creating great backing data stores for your react app.
+By following the patterns established by react-redux, but avoiding the complexity of pure-functional programing, reducer composition, immutability, and the single store paradigm, we hope to offer a familiar, powerful, but far simpler solution to creating great state management and data stores for your react app.
 
 ## License
 [MIT](./LICENSE)

--- a/test/test.js
+++ b/test/test.js
@@ -1,9 +1,10 @@
 import QUnit from 'steal-qunit';
-import { connect } from '../react-view-models';
+import connect, { nobind, asArray } from '../react-view-models';
 import React from 'react';
 import compute from 'can-compute';
 import ReactTestUtils from 'react-addons-test-utils';
-import DefineMap from 'can-define/map/';
+import DefineMap from 'can-define/map/map';
+import DefineList from 'can-define/list/list';
 
 QUnit.module('react-view-models', () => {
 
@@ -20,7 +21,7 @@ QUnit.module('react-view-models', () => {
       shallowRenderer = ReactTestUtils.createRenderer();
     });
 
-    QUnit.module('with a map to props function', () => {
+    QUnit.module('with a mapToProps function', () => {
 
       QUnit.test('should not (by default) render additional dom nodes that the ones from the extended Presentational Component', (assert) => {
 
@@ -84,13 +85,15 @@ QUnit.module('react-view-models', () => {
         foobar: {
           get() {
             return this.foo + this.bar;
-          },
-          serialize: true
+          }
         },
         zzz: {
           set( newVal ) {
             return newVal.toUpperCase();
           }
+        },
+        list: {
+          value: new DefineList(['one'])
         },
         returnContext() {
           return this;
@@ -105,8 +108,7 @@ QUnit.module('react-view-models', () => {
                 return lastSetValue(...args);
               }
             };
-          },
-          serialize: true
+          }
         }
       });
 
@@ -116,15 +118,11 @@ QUnit.module('react-view-models', () => {
         assert.ok( connectedInstance.viewModel instanceof DefinedViewModel );
       });
 
-      QUnit.test('should pass a props object with copied methods, that have the correct context (the viewmodel) for callbacks', (assert) => {
-        const ConnectedComponent = connect( DefinedViewModel, TestComponent );
-        const connectedInstance = ReactTestUtils.renderIntoDocument( React.createElement( ConnectedComponent ) );
-        const childComponent = ReactTestUtils.scryRenderedComponentsWithType(connectedInstance, TestComponent)[0];
-        assert.equal(childComponent.props.returnContext(), connectedInstance.viewModel);
-      });
-
       QUnit.test('should update whenever any observable property on the viewModel instance changes', (assert) => {
-        const ConnectedComponent = connect( DefinedViewModel, TestComponent );
+        const properties = {
+          foobar: true
+        };
+        const ConnectedComponent = connect( DefinedViewModel, TestComponent, { properties } );
         const el = React.createElement( ConnectedComponent, { bar: 'bar', baz: 'bam' } );
         const connectedInstance = ReactTestUtils.renderIntoDocument( el );
         const childComponent = ReactTestUtils.scryRenderedComponentsWithType( connectedInstance, TestComponent )[0];
@@ -135,7 +133,10 @@ QUnit.module('react-view-models', () => {
       });
 
       QUnit.test('should update the component when new props are received', (assert) => {
-        const ConnectedComponent = connect( DefinedViewModel, TestComponent );
+        const properties = {
+          bar: true
+        };
+        const ConnectedComponent = connect( DefinedViewModel, TestComponent, { properties } );
         const WrappingComponent = React.createClass({
           getInitialState() {
             return { barValue: 'Initial Prop Value' };
@@ -157,7 +158,11 @@ QUnit.module('react-view-models', () => {
       });
 
       QUnit.test('should update the viewModel when new props are received', (assert) => {
-        const ConnectedComponent = connect( DefinedViewModel, TestComponent );
+        const properties = {
+          bar: true,
+          foobar: true
+        };
+        const ConnectedComponent = connect( DefinedViewModel, TestComponent, { properties } );
         const WrappingComponent = React.createClass({
           getInitialState() {
             return { bar: 'bar' };
@@ -179,7 +184,10 @@ QUnit.module('react-view-models', () => {
       });
 
       QUnit.test('should use the viewModels props value, if the viewModel changes, and no new props are received', (assert) => {
-        const ConnectedComponent = connect( DefinedViewModel, TestComponent );
+        const properties = {
+          foobar: true
+        };
+        const ConnectedComponent = connect( DefinedViewModel, TestComponent, { properties } );
         const WrappingComponent = React.createClass({
           getInitialState() {
             return { bar: 'bar' };
@@ -199,7 +207,10 @@ QUnit.module('react-view-models', () => {
 
       QUnit.test('should be able to call the props.interceptedCallback function received from parent component', (assert) => {
         const expectedValue = [];
-        const ConnectedComponent = connect( DefinedViewModel, TestComponent );
+        const properties = {
+          interceptedCallback: true
+        };
+        const ConnectedComponent = connect( DefinedViewModel, TestComponent, { properties } );
         const WrappingComponent = React.createClass({
           parentCallBack() { return expectedValue; },
           render() {
@@ -218,12 +229,134 @@ QUnit.module('react-view-models', () => {
       });
 
       QUnit.test('should be able to have the viewModel transform props before passing to child component', (assert) => {
-        const ConnectedComponent = connect( DefinedViewModel, TestComponent );
+        const properties = {
+          zzz: true
+        };
+        const ConnectedComponent = connect( DefinedViewModel, TestComponent, { properties } );
         const el = React.createElement( ConnectedComponent, { zzz: 'zzz' } );
         const connectedInstance = ReactTestUtils.renderIntoDocument( el );
         const childComponent = ReactTestUtils.scryRenderedComponentsWithType( connectedInstance, TestComponent )[0];
 
         assert.equal(childComponent.props.zzz, 'ZZZ');
+      });
+
+      QUnit.module(`OPTIONS 'properties'`, () => {
+
+        QUnit.test(`should pass vm 'keys' with a truthy value in the 'properties' object to the connected component`, (assert) => {
+          const properties = {
+            foo: false,
+            bar: true
+          };
+          const ConnectedComponent = connect( DefinedViewModel, TestComponent, { properties } );
+          const el = React.createElement( ConnectedComponent, { bar: 'bar', foo: 'foo' } );
+          const connectedInstance = ReactTestUtils.renderIntoDocument( el );
+          const childComponent = ReactTestUtils.scryRenderedComponentsWithType( connectedInstance, TestComponent )[0];
+          assert.equal(childComponent.props.foo, undefined);
+          assert.equal(childComponent.props.bar, 'bar');
+        });
+
+        QUnit.test(`should pass a props object with methods that have been bound
+                    the correct context (the viewmodel) for callbacks`, (assert) => {
+          const ConnectedComponent = connect( DefinedViewModel, TestComponent, { properties: { returnContext: true } } );
+          const connectedInstance = ReactTestUtils.renderIntoDocument( React.createElement( ConnectedComponent ) );
+          const childComponent = ReactTestUtils.scryRenderedComponentsWithType(connectedInstance, TestComponent)[0];
+          assert.equal(childComponent.props.returnContext(), connectedInstance.viewModel);
+        });
+
+        QUnit.test(`should pass vm 'keys' with the *special value* 'nobind' in the
+                    'properties' object to the connected component without binding
+                    the method to the vm`, (assert) => {
+          const ConnectedComponent = connect( DefinedViewModel, TestComponent, { properties: { returnContext: nobind } } );
+          const connectedInstance = ReactTestUtils.renderIntoDocument( React.createElement( ConnectedComponent ) );
+          const childComponent = ReactTestUtils.scryRenderedComponentsWithType(connectedInstance, TestComponent)[0];
+          const ctx = {};
+          assert.notEqual(childComponent.props.returnContext.call(ctx), connectedInstance.viewModel);
+          assert.equal(childComponent.props.returnContext.call(ctx), ctx);
+        });
+
+        QUnit.test(`should pass vm 'keys' with the *special value* 'asArray' in the
+                    'properties' object to the connected component after converting
+                    array-like objects (like DefineLists) to an actual array`, (assert) => {
+          const ConnectedComponent = connect( DefinedViewModel, TestComponent, { properties: { list: asArray } } );
+          const connectedInstance = ReactTestUtils.renderIntoDocument( React.createElement( ConnectedComponent ) );
+          const childComponent = ReactTestUtils.scryRenderedComponentsWithType(connectedInstance, TestComponent)[0];
+          assert.equal(Object.getPrototypeOf( childComponent.props.list ), Array.prototype);
+        });
+
+      });
+
+      QUnit.module(`OPTIONS 'deepObserve'`, () => {
+
+        QUnit.test(`should be able to update the component, when a nested observable
+                    property changes, if the 'deepObserve' options is true`, (assert) => {
+          const Person = DefineMap.extend({
+            name: {
+              type: 'string',
+              value: 'Adam'
+            }
+          });
+          const DefinedViewModel = DefineMap.extend({
+            person: {
+              Value: Person
+            }
+          });
+          const properties = {
+            person: true
+          };
+          const Component = ({ person }) => {
+            return <div className="person-div">{ person.name }</div>;
+          };
+          Component.propTypes = { person: React.PropTypes.any };
+          const ConnectedComponent = connect( DefinedViewModel, Component, { properties, deepObserve: true } );
+          const el = React.createElement( ConnectedComponent, {} );
+          const connectedInstance = ReactTestUtils.renderIntoDocument( el );
+          const div = ReactTestUtils.scryRenderedDOMComponentsWithTag( connectedInstance, 'div' )[0];
+          assert.equal(div.textContent, 'Adam');
+          connectedInstance.viewModel.person.name = 'Marshall';
+          assert.equal(div.textContent, 'Marshall');
+        });
+
+      });
+
+    });
+
+    QUnit.module(`OPTIONS 'displayName'`, (hooks) => {
+      let origDisplayName;
+
+      hooks.beforeEach(()=>{
+        origDisplayName = TestComponent.displayName;
+        TestComponent.displayName = '???';
+      });
+      hooks.afterEach(()=>{
+        TestComponent.displayName = origDisplayName;
+      });
+
+      QUnit.test(`should set the components 'displayName' for React Dev tools when set in
+                  the options`, (assert) => {
+        const expectedValue = 'ThisIsTheComponentName';
+        const DefinedViewModel = DefineMap.extend({});
+        const ConnectedComponent = connect( DefinedViewModel, TestComponent, { displayName: expectedValue } );
+        assert.equal(ConnectedComponent.displayName, expectedValue);
+      });
+
+      QUnit.test(`should set the components 'displayName' to a default value wrapping
+                  the child components 'displayName' in "Connected(*)" if NOT set
+                  in the options`, (assert) => {
+        const expectedValue = 'Connected(???)';
+        const ConnectedComponent = connect( p=>p, TestComponent );
+        assert.equal(ConnectedComponent.displayName, expectedValue);
+      });
+
+      QUnit.test(`should set the components 'displayName' to a default value
+                  "Connected(Component)" if the child component does not have a
+                  display name of function name`, (assert) => {
+        const expectedStatelessValue = 'Connected(statelessComponent)';
+        const statelessComponent = ()=>null;
+        const ConnectedStatelessComponent = connect( p=>p, statelessComponent );
+        assert.equal(ConnectedStatelessComponent.displayName, expectedStatelessValue);
+        const expectedValue = 'Connected(Component)';
+        const ConnectedComponent = connect( p=>p, ()=>null );
+        assert.equal(ConnectedComponent.displayName, expectedValue);
       });
 
     });

--- a/test/test.js
+++ b/test/test.js
@@ -283,6 +283,44 @@ QUnit.module('react-view-models', () => {
           assert.equal(Object.getPrototypeOf( childComponent.props.list ), Array.prototype);
         });
 
+        QUnit.test(`should pass all remaining ownProps to the child component if
+                    the special key '...' is truthy`, (assert) => {
+          const ownProps = {
+            someProp: 'Here is something',
+            anotherProp: 3,
+            bar: 'bar',
+            foobar: 'This should get overwritten by view-models foo'
+          };
+          const properties = {
+            '...': true,
+            'foobar': true
+          };
+          const ConnectedComponent = connect( DefinedViewModel, TestComponent, { properties } );
+          const connectedInstance = ReactTestUtils.renderIntoDocument( React.createElement( ConnectedComponent, ownProps ) );
+          const childComponent = ReactTestUtils.scryRenderedComponentsWithType(connectedInstance, TestComponent)[0];
+          assert.equal(childComponent.props.someProp, ownProps.someProp);
+          assert.equal(childComponent.props.anotherProp, ownProps.anotherProp);
+          assert.equal(childComponent.props.foobar, 'foobar');
+        });
+
+
+        QUnit.test(`should not pass certain ownProps to the child component if
+                    the special key '...' is truthy, but the properties key is false`, (assert) => {
+          const ownProps = {
+            someProp: 'Here is something',
+            anotherProp: 3
+          };
+          const properties = {
+            '...': true,
+            'anotherProp': false
+          };
+          const ConnectedComponent = connect( DefinedViewModel, TestComponent, { properties } );
+          const connectedInstance = ReactTestUtils.renderIntoDocument( React.createElement( ConnectedComponent, ownProps ) );
+          const childComponent = ReactTestUtils.scryRenderedComponentsWithType(connectedInstance, TestComponent)[0];
+          assert.equal(childComponent.props.someProp, ownProps.someProp);
+          assert.equal(childComponent.props.anotherProp, undefined);
+        });
+
       });
 
       QUnit.module(`OPTIONS 'deepObserve'`, () => {


### PR DESCRIPTION
This PR changes `react-view-models` so that there is no need to serialize the observables, and because descendant observables  are passed directly into the React components, there is no need for tricky singleton work arounds to connect view-models with the appropriate state objects.

The **trade off** for these benefits is that you must now _explicitly state_ which view-model properties you are sending to the child "presentational" component as props, on only changes to those properties in particular will cause re-renders.

The explicit declaration happens in the options object, along with some other helpful options, documented in this PR as well.

Resolves #3 
Resolves #5 
Resolves #6 
Resolves #9 